### PR TITLE
read from stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+markli-testdir/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,7 +237,6 @@ linters:
     - gochecknoglobals
     - golint
     - lll
-    - gomnd
   disable-all: false
   presets:
     - bugs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,6 +237,7 @@ linters:
     - gochecknoglobals
     - golint
     - lll
+    - gomnd
   disable-all: false
   presets:
     - bugs

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestExecEmpty(t *testing.T) {
+	args := []string{"markli"}
+	stdin := strings.NewReader("")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err := exec(args, stdin, stdout, stderr)
+
+	assert.Assert(t, errors.Is(err, NoInputError))
+	assert.Assert(t, strings.Contains(stderr.String(), "Usage of"))
+	assert.Assert(t, strings.Contains(stderr.String(), "-i, --input"))
+}
+
+func TestExecNonExisting(t *testing.T) {
+	args := []string{"markli", "-i", "/nonexisting"}
+	stdin := strings.NewReader("")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err := exec(args, stdin, stdout, stderr)
+
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestExecInvalidCmd(t *testing.T) {
+	args := []string{"markli", "--foo"}
+	stdin := strings.NewReader("")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err := exec(args, stdin, stdout, stderr)
+
+	assert.ErrorContains(t, err, "unknown flag")
+}
+
+func TestExecStdInAndInputError(t *testing.T) {
+	args := []string{"markli", "--input=foo", "-i -"}
+	stdin := strings.NewReader("")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err := exec(args, stdin, stdout, stderr)
+
+	assert.Assert(t, errors.Is(err, StdinMustBeOnlyArgumentError))
+}
+func TestExecStdin(t *testing.T) {
+	dir := getTempDir(t)
+	args := []string{"markli", "-v", "-i -", "-o " + dir}
+	stdin := strings.NewReader("Foo\n```sh\n### FILE-CRLF: foo.txt\nHello, World\n```\n")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err := exec(args, stdin, stdout, stderr)
+
+	assert.NilError(t, err)
+	// Make sure -v works
+	assert.Assert(t, stdout.String() != "")
+
+	files := []string{
+		"foo.txt",
+	}
+
+	validateFile(t, "foo.txt", []byte("Hello, World\r\n"))
+	validateDirStruct(t, dir, files)
+}
+
+func TestExecEmptyPathPragmaStdin(t *testing.T) {
+	dir := getTempDir(t)
+	args := []string{"markli", "-v", "-i -", "-o " + dir}
+	stdin := strings.NewReader("Foo\n```sh\n### FILE-CRLF: \nHello, World\n```\n")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err := exec(args, stdin, stdout, stderr)
+
+	assert.NilError(t, err)
+	// Make sure -v works
+	outstr := stdout.String()
+	t.Logf("stdout: [%s]\n", outstr)
+	assert.Assert(t, strings.Contains(outstr, "ignoring empty path"))
+}
+
+func TestExecFile(t *testing.T) {
+	dir := getTempDir(t)
+
+	hw := []byte("Foo\n```sh\n### FILE-CRLF: foo.txt\nHello, World\n```\n")
+	err := ioutil.WriteFile(dir+"/input.md", hw, 0644)
+	assert.NilError(t, err)
+
+	args := []string{"markli", "-i " + dir + "/input.md", "-o " + dir}
+	stdin := bytes.NewBufferString("")
+	stdout := bytes.NewBufferString("")
+	stderr := bytes.NewBufferString("")
+
+	err = exec(args, stdin, stdout, stderr)
+
+	assert.NilError(t, err)
+
+	files := []string{
+		"input.md",
+		"foo.txt",
+	}
+
+	validateFile(t, "foo.txt", []byte("Hello, World\r\n"))
+	validateDirStruct(t, dir, files)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/lichtzeichner/markli
 
 require (
-	github.com/google/go-cmp v0.3.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/google/go-cmp v0.4.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5
-	github.com/yuin/goldmark v1.1.14
+	github.com/yuin/goldmark v1.1.32
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,17 @@
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
+github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/yuin/goldmark v1.1.14 h1:9/OvYI+gdtQ5EAZY0y4kuVnuKjlE03BRqTw/njWYRNo=
 github.com/yuin/goldmark v1.1.14/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.1.32 h1:5tjfNdR2ki3yYQ842+eX2sQHeiwpKJ0RnHO4IYOc4V8=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/main.go
+++ b/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -20,8 +22,11 @@ type logger struct {
 	outstream io.Writer
 }
 
+var NoInputError = errors.New("No inputs specified")
+var StdinMustBeOnlyArgumentError = errors.New("If stdin is specified, it must be the only input argument")
+
 func (l *logger) printf(verbosity int, format string, a ...interface{}) {
-	if verbosity <= l.verbosity {
+	if l.outstream != nil && verbosity <= l.verbosity {
 		fmt.Fprintf(l.outstream, format, a...)
 	}
 }
@@ -40,7 +45,7 @@ func (l *logger) verbose3f(format string, a ...interface{}) {
 
 var log *logger = &logger{
 	verbosity: 0,
-	outstream: os.Stderr,
+	outstream: nil,
 }
 
 func render(inputs [][]byte) (map[string][]byte, error) {
@@ -78,52 +83,86 @@ func writeRendered(outDir string, output map[string][]byte) error {
 		dir := filepath.Dir(path)
 		log.verbosef("Writing output: %s\n", path)
 
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return err
-		}
-
-		if err := ioutil.WriteFile(path, content, 0755); err != nil {
-			return err
+		if err := os.MkdirAll(dir, 0755); err == nil {
+			if err := ioutil.WriteFile(path, content, 0755); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-func main() {
+func exec(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	log.outstream = stdout
+
 	var inputFiles []string
 	var outDir string
 	var rendered map[string][]byte
 
-	flag.StringArrayVarP(&inputFiles, "input", "i", []string{}, "Markdown file to process, can be given multiple times")
-	flag.StringVarP(&outDir, "out-dir", "o", ".", "Output directory.")
-	flag.CountVarP(&log.verbosity, "verbose", "v", "Control verbosity, shorthand can be given multiple times")
-	flag.Parse()
+	appname := filepath.Base(args[0])
+
+	flags := flag.NewFlagSet(appname, flag.ContinueOnError)
+	flags.StringArrayVarP(&inputFiles, "input", "i", []string{}, "Markdown file to process, can be given multiple times. Use - to read from stdin.")
+	flags.StringVarP(&outDir, "out-dir", "o", ".", "Output directory.")
+	flags.CountVarP(&log.verbosity, "verbose", "v", "Control verbosity, shorthand can be given multiple times")
+	flags.SetOutput(stderr)
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
 
 	inputCnt := len(inputFiles)
 
 	if inputCnt == 0 {
-		fmt.Fprint(os.Stderr, "No inputs specified\n")
-		flag.Usage()
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Usage of %s:\n", appname)
+		flags.PrintDefaults()
+		return NoInputError
+	}
+
+	for _, file := range inputFiles {
+		if strings.TrimSpace(file) == "-" && inputCnt > 1 {
+			return StdinMustBeOnlyArgumentError
+		}
 	}
 
 	inputs := make([][]byte, 0, inputCnt)
 
-	for _, file := range inputFiles {
+	trimmedFiles := make([]string, inputCnt)
+	for idx, file := range inputFiles {
+		trimmedFiles[idx] = strings.TrimSpace(file)
+	}
+
+	for _, file := range trimmedFiles {
 		log.verbose2f("Processing file %s\n", file)
-		input, err := ioutil.ReadFile(file)
+		var input []byte
+		var err error
+
+		if file == "-" {
+			input, err = ioutil.ReadAll(stdin)
+		} else {
+			input, err = ioutil.ReadFile(file)
+		}
 		if err != nil {
-			panic(err)
+			return err
 		}
 		inputs = append(inputs, input)
 	}
 
 	rendered, err := render(inputs)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	if err := writeRendered(outDir, rendered); err != nil {
-		panic(err)
+	if err := writeRendered(strings.TrimSpace(outDir), rendered); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := exec(os.Args, os.Stdin, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ type logger struct {
 }
 
 var NoInputError = errors.New("No inputs specified")
-var StdinMustBeOnlyArgumentError = errors.New("If stdin is specified, it must be the only input argument")
 
 func (l *logger) printf(verbosity int, format string, a ...interface{}) {
 	if l.outstream != nil && verbosity <= l.verbosity {
@@ -117,12 +116,6 @@ func exec(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stderr, "Usage of %s:\n", appname)
 		flags.PrintDefaults()
 		return NoInputError
-	}
-
-	for _, file := range inputFiles {
-		if strings.TrimSpace(file) == "-" && inputCnt > 1 {
-			return StdinMustBeOnlyArgumentError
-		}
 	}
 
 	inputs := make([][]byte, 0, inputCnt)

--- a/output_test.go
+++ b/output_test.go
@@ -35,7 +35,7 @@ func validateFile(t *testing.T, path string, expected []byte) {
 		t.Fatal("Could not find base dir for test: " + t.Name())
 	}
 	file := filepath.Join(dir, path)
-	t.Logf("File: %s\n", file)
+	t.Logf("File: [%s]\n", file)
 	info, err := os.Stat(file)
 	assert.Assert(t, os.IsNotExist(err) == false)
 	assert.Assert(t, !info.IsDir())

--- a/scriptrenderer.go
+++ b/scriptrenderer.go
@@ -50,13 +50,13 @@ func parseLineEndingStyle(style string) lineEndingStyle {
 // IsAbs() returns false for /etc/passwd on windows
 // But if you do mkdir(/etc/passwd) you end up with C:/etc/passwd,
 // this is *not* what we want
-// therefore use filepath and check for / additionally
+// therefore use filepath and check for / additionally.
 func isAbs(path string) bool {
 	return filepath.IsAbs(path) || strings.HasPrefix(path, "/")
 }
 
 // filepath.ToSlash() and .Clean() have platform-dependent behavior
-// this is not helpful in this case
+// this is not helpful in this case.
 func hasDirUp(path string) bool {
 	for _, element := range strings.Split(path, "/") {
 		if element == ".." {
@@ -153,8 +153,6 @@ func (r *scriptRenderer) renderCodeBlock(w util.BufWriter, source []byte, node a
 						ending = desiredEnding
 					}
 					switch {
-					case p == "":
-						log.verbosef("Warning: ingoring empty path\n")
 					case isAbs(p):
 						log.verbosef("Warning: absolute paths are not allowed, ignoring path: %s\n", p)
 					case hasDirUp(p):
@@ -165,6 +163,7 @@ func (r *scriptRenderer) renderCodeBlock(w util.BufWriter, source []byte, node a
 					}
 				}
 				if path == "" {
+					log.verbosef("Warning: ignoring empty path\n")
 					return ast.WalkContinue, nil
 				}
 				log.verbose3f("Adding script '%s' with line ending '%s'\n", path, ending.String())


### PR DESCRIPTION
markli learns to read directly from stdin instead of only from local files, this fixes #12 

main function is refactored to allow for much greater test coverage, as the bulk of work is refactored out into a testable "exec" function. Dependency on globals (os.Args, stdin, stdout, global flag definition) is reduced as much as possible.